### PR TITLE
Try to update already existing featured items

### DIFF
--- a/includes/class-customizer.php
+++ b/includes/class-customizer.php
@@ -306,7 +306,7 @@ class Customizer {
 					$query = new \WP_Query(
 						array(
 							'post_type'      => 'featured-content',
-							'post_status'    => 'publish',
+							'post_status'    => [ 'publish', 'future' ],
 							'fields'         => 'ids',
 							'posts_per_page' => 200,
 							'tax_query'      => [


### PR DESCRIPTION
Instead of deleting all featured items and then creating new ones everytime the customizer is saved, this PR tries to match if a featured item already exists as published in the same featured area and if so updates that one instead.