### PR TITLE
Add a filter to the searchable post types

### DIFF
--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -52,7 +52,7 @@ class Rest {
 	public static function search_posts( \WP_REST_Request $request ) {
 		$search_term = ( isset( $request['s'] ) ? $request['s'] : '' );
 		$args        = array(
-			'post_type'      => 'post',
+			'post_type'      => apply_filters( 'fcm_post_type', [ 'post' ] ),
 			'posts_per_page' => 10,
 			'post_status'    => apply_filters( 'fcm_post_status', [ 'publish', 'future' ] ),
 			's'              => $search_term,


### PR DESCRIPTION
Adds the  'fcm_post_type' filter to the search query for items in the customizer. Makes it so that themes can extend this and add other post types to the featured areas.