### PR TITLE
Make sure an instance of WP_Term is passed to prepare term

### DIFF
--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -117,7 +117,7 @@ class Rest {
 	public static function fcm_term_filter_result( $result = array() ) {
 		$filtered_result = array();
 		foreach ( $result as $term ) {
-			$filtered_result[] = self::prepare_term( $term );
+			$filtered_result[] = self::prepare_term( get_term( $term ) );
 		}
 		return $filtered_result;
 	}


### PR DESCRIPTION
When a term search if made via Elasticpress a stdclass is returned instead of a WP_Term object. This makes sure that a WP_Term object is passed to prepare_term by calling get_term on the result.