### PR TITLE
Add filter to fcm_post_search orderby

### DIFF
--- a/includes/class-rest.php
+++ b/includes/class-rest.php
@@ -55,6 +55,7 @@ class Rest {
 			'posts_per_page' => 10,
 			'post_status'    => apply_filters( 'fcm_post_status', array( 'publish', 'future' ) ),
 			's'              => $args['search_term'],
+			'orderby'        => apply_filters( 'fcm_post_orderby', 'date' ),
 		);
 		$result = get_posts( $query );
 		return $result;


### PR DESCRIPTION
Had some complaints from customers that the results when searching for posts in fcm was not satisfactory. Tracked this down to the use of `get_posts` here which sets `orderby => date` as default. This means that ElasticPress will not add it's own `orderby => _score` and the results will be quite bad. To not break BC I've added this as a filter so the sites that uses ElasticPress can do something like this:

```PHP
/**
 * Return an empty string for fcm orderby.
 * This is so that ElasticPress will use _score instead of date for ordering.
 */
add_filter(
	'fcm_post_orderby',
	function(): string {
		return '';
	}
);
```