### PR TITLE
Fix 'headers already sent' warning in customizer

### DIFF
--- a/featured-content-manager.php
+++ b/featured-content-manager.php
@@ -37,7 +37,6 @@ add_action(
 	'init',
 	function() {
 		if ( current_theme_supports( 'featured-content-manager' ) ) {
-			add_action( 'customize_controls_enqueue_scripts', array( 'Featured_Content_Manager\Customizer', 'customizer_css' ) );
 			add_action( 'customize_register', array( 'Featured_Content_Manager\Customizer', 'customize_register' ) );
 			add_action( 'customize_controls_enqueue_scripts', array( 'Featured_Content_Manager\Customizer', 'enqueue_customize_control' ) );
 			add_action( 'customize_controls_print_footer_scripts', array( 'Featured_Content_Manager\Customizer', 'customize_print_featured_item_template' ) );

--- a/includes/class-customizer.php
+++ b/includes/class-customizer.php
@@ -85,6 +85,7 @@ class Customizer {
 			filemtime( dirname( __DIR__, 1 ) . '/dist/css/customizer.css' ),
 			'screen'
 		);
+		wp_add_inline_style( 'featured-area-style', self::get_customizer_css() );
 		wp_enqueue_script(
 			'whatwg-fetch-script',
 			plugins_url( 'dist/js/fetch.js', dirname( __FILE__ ) ),
@@ -191,34 +192,27 @@ class Customizer {
 	/**
 	 * Print some *hack* css style.
 	 */
-	public static function customizer_css() {
+	public static function get_customizer_css() {
 		$featured_areas = Featured_Content::get_featured_areas();
-		?>
-		<style type="text/css">
-		<?php
+		$css            = '';
 		foreach ( $featured_areas as $id => $featured_area ) {
 			$levels    = $featured_area['levels'] ?? 0;
 			$max       = isset( $featured_area['max'] ) ? $featured_area['max'] + 1 : 11; // Setting this to +1 to get the :before css at the right place.
 			$level_css = '';
 			for ( $i = 1; $i < $levels; $i++ ) {
 				$level_css .= '>li>ol';
-				echo "ol#{$id}{$level_css} { display: block; }\n";
+				$css       .= "ol#{$id}{$level_css} { display: block; }";
 			}
-
-			?>
-			ol#<?php echo esc_attr( $id ); ?> li:nth-child(<?php echo esc_attr( $max ); ?>)::before {
+			$css .= 'ol#' . esc_attr( $id ) . ' li:nth-child(' . esc_attr( $max ) . ')::before {
 				content: "";
 				border-bottom: 1px dashed lightgray;
 				margin: 10px 0;
 				display: block;
 				-webkit-font-smoothing: antialiased;
 				-moz-osx-font-smoothing: grayscale;
-			}
-			<?php
+			}';
 		}
-		?>
-		</style>
-		<?php
+		return $css;
 	}
 
 	/**


### PR DESCRIPTION
@redundans I noticed some php warnings in the customizer relating to the output of CSS in this method, seems to be fixed by using `wp_add_inline_style` instead of just echoing the css.